### PR TITLE
Use actions/checkout@v4.1.1 to mitigate git2r error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Cache artifacts 📀
         uses: actions/cache@v4
@@ -100,7 +100,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Cache artifacts 📀
         uses: actions/cache@v4
@@ -164,7 +164,7 @@ jobs:
         && !contains(github.event.commits[0].message, '[skip docs]')
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Download artifact ⏬
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Pin the checkout action to v4.1.1 since v4.1.3 is broken.