### PR TITLE
Replacing Deprecated Function

### DIFF
--- a/tables/DT1/dt01.qmd
+++ b/tables/DT1/dt01.qmd
@@ -17,7 +17,7 @@ The simplest demographics table DT1 splits the columns by treatment arm and All 
 lyt <- basic_table() %>%
   split_cols_by("ARM") %>%
   split_cols_by_groups("BEP01FL", bep_groups) %>%
-  summarize_vars(c("AGE", "SEX")) %>%
+  analyze_vars(c("AGE", "SEX")) %>%
   add_colcounts()
 
 build_table(lyt, adsl)

--- a/tables/DT1/dt01a.qmd
+++ b/tables/DT1/dt01a.qmd
@@ -17,7 +17,7 @@ We can reorder the treatment arm columns in the demographics table DT1 by using 
 lyt <- basic_table() %>%
   split_cols_by("ARM", split_fun = reorder_split_levels(c("B: Placebo", "A: Drug X", "C: Combination"))) %>%
   split_cols_by_groups("BEP01FL", bep_groups) %>%
-  summarize_vars(c("AGE", "SEX")) %>%
+  analyze_vars(c("AGE", "SEX")) %>%
   add_colcounts()
 
 build_table(lyt, adsl)

--- a/tables/DT1/dt01b.qmd
+++ b/tables/DT1/dt01b.qmd
@@ -16,7 +16,7 @@ It is simple to omit the treatment arm split in the demographics table DT1, thus
 ```{r}
 lyt <- basic_table() %>%
   split_cols_by_groups("BEP01FL", bep_groups) %>%
-  summarize_vars(c("AGE", "SEX")) %>%
+  analyze_vars(c("AGE", "SEX")) %>%
   add_colcounts()
 
 build_table(lyt, adsl)

--- a/tables/DT1/dt01c.qmd
+++ b/tables/DT1/dt01c.qmd
@@ -22,7 +22,7 @@ bep2_groups <- list(
 lyt <- basic_table() %>%
   split_cols_by("ARM") %>%
   split_cols_by_groups("BEP02FL", bep2_groups) %>%
-  summarize_vars(c("AGE", "SEX")) %>%
+  analyze_vars(c("AGE", "SEX")) %>%
   add_colcounts()
 
 build_table(lyt, adsl)

--- a/tables/DT2/dt02.qmd
+++ b/tables/DT2/dt02.qmd
@@ -19,7 +19,7 @@ lyt <- basic_table() %>%
   split_cols_by("ARM") %>%
   add_colcounts() %>%
   split_cols_by("BEP01FL", labels_var = "BEP_label") %>%
-  summarize_vars(c("AGE", "SEX"))
+  analyze_vars(c("AGE", "SEX"))
 
 build_table(lyt, adsl)
 ```

--- a/tables/TET1/tet01.qmd
+++ b/tables/TET1/tet01.qmd
@@ -20,14 +20,14 @@ lyt <- basic_table() %>%
     ref_group = "CTRL"
   ) %>%
   add_colcounts() %>%
-  summarize_vars(
+  analyze_vars(
     vars = "is_event",
     .stats = "count_fraction",
     .labels = c(count_fraction = "Patients with event (%)"),
     nested = FALSE,
     show_labels = "hidden"
   ) %>%
-  summarize_vars(
+  analyze_vars(
     vars = "is_not_event",
     .stats = "count_fraction",
     .labels = c(count_fraction = "Patients without event (%)"),

--- a/tables/TET1/tet01a.qmd
+++ b/tables/TET1/tet01a.qmd
@@ -20,14 +20,14 @@ lyt <- basic_table() %>%
     ref_group = "CTRL"
   ) %>%
   add_colcounts() %>%
-  summarize_vars(
+  analyze_vars(
     vars = "is_event",
     .stats = "count_fraction",
     .labels = c(count_fraction = "Patients with event (%)"),
     nested = FALSE,
     show_labels = "hidden"
   ) %>%
-  summarize_vars(
+  analyze_vars(
     vars = "is_not_event",
     .stats = "count_fraction",
     .labels = c(count_fraction = "Patients without event (%)"),


### PR DESCRIPTION
The function summarize_vars() has been deprecated and no longer works. It was uses in tables DT1, DT2, and TET1. A new function analyze_vars() is a renamed version of summarize_vars(). All occurrences of the deprecated function have been replaced in this pull request.

[https://github.com/search?q=repo%3Ainsightsengineering%2Fbiomarker-catalog%20summarize_vars&type=code](https://github.com/search?q=repo%3Ainsightsengineering%2Fbiomarker-catalog%20summarize_vars&type=code)

7 files are updated with 9 occurrences.